### PR TITLE
Security fixes 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,36 +18,36 @@ Run the HAT to ensure that the tool executes correctly.
 Alternatively, you can make use of the installer (installer.sh) that has been included since HAT version 0.4. If, after using the installer, the tool is not working properly, check for fulfillment of the points above from the manual installation instructions.
 
 # RUNNING THE SCRIPT
-To run the HAT, simply execute the tool by executing ($ just means execute in the terminal):
-$ hat
+To run the HAT, simply execute the tool by executing ($ just means execute in the terminal):  
+> `$ hat`
 ### NOTE: Not all capabilities of the HAT will be available without running the tool as root
 
-To run the tool as root (to access more capabilities), execute the following:
-$ sudo hat
+To run the tool as root (to access more capabilities), execute the following:  
+> `$ sudo hat`  
 ### NOTE: Always be careful with any file manipulations when using sudo
 
 Once the tool has been executed, the tool will prompt you for any interaction that it needs.
 
 # CURRENT CAPABILITIES
-Capabilities that begin with ROOT can only be used when running HAT as root.
-Output the current number of caught binaries
-Output the current size of the dionaea log file
-ROOT: Reset the dionaea log file by deleting the current file and creating a new, empty log file and restarting the dionaea service
-Output the current list of binaries (as a Filtered or Unfiltered list, or No list to skip this capability)
-The Filtered list does not contain any of the zero-sized “http*” files that dionaea includes in its */binaries/ directory.
-The Unfiltered list contains all files in the */binaries/ directory.
-The No list option skips the printing of a list of binaries.
-ROOT: Copy the binaries from the directory where they are stored by dionaea into a user-specified directory.
-Run VirusTotal scans on all of the binaries in the specified directory. (The user must have access privileges to the specified directory) using the Sample Scanner tool (provided alongside HAT). This capability currently runs into an error when running as root.
+Capabilities that begin with **ROOT** can only be used when running HAT as root.
+- Output the current number of caught binaries
+- Output the current size of the dionaea log file
+- **ROOT**: Reset the dionaea log file by deleting the current file and creating a new, empty log file and restarting the dionaea service
+- Output the current list of binaries (as a Filtered or Unfiltered list, or No list to skip this capability)
+    - The Filtered list does not contain any of the zero-sized “http*” files that dionaea includes in its */binaries/ directory.
+    - The Unfiltered list contains all files in the */binaries/ directory.
+    - The No list option skips the printing of a list of binaries.
+- **ROOT**: Copy the binaries from the directory where they are stored by dionaea into a user-specified directory.
+- Runs VirusTotal scans on all of the binaries in the specified directory (The user must have access privileges to the specified directory) using the Sample Scanner tool (provided alongside HAT).
 The following VirusTotalApi tool is required for this capability: https://github.com/doomedraven/VirusTotalApi
 
 # KNOWN ISSUES
 Currently, once the tool is correctly installed to the /bin directory, the Sample Scanner tool may produce some issues regarding some Python libraries not being accessible (among ones that have had these issues are python.dateutil and texttable).
 
-To fix the issues with python.dateutil and texttable, run the following two commands:
+To fix the issues with python.dateutil and texttable, run the following two commands:  
 
-$ sudo pip install python-dateutil --upgrade
-$ sudo pip install texttable --upgrade
+> `$ sudo pip install python-dateutil --upgrade`  
+> `$ sudo pip install texttable --upgrade`
 
 You should now be able to run HAT as root and use the VirusTotal scanning capability run by Sample Scanner and vt.py.
 

--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ $ sudo pip install python-dateutil --upgrade
 $ sudo pip install texttable --upgrade
 
 You should now be able to run HAT as root and use the VirusTotal scanning capability run by Sample Scanner and vt.py.
+
+# Script Security Checks
+Currently, the scripts are being run through the Shell Check tool located at https://www.shellcheck.net/ to find possible flaws. As more tools are found or suggested, the scripts can be further checked.

--- a/hat
+++ b/hat
@@ -1,5 +1,28 @@
 #!/usr/bin/env bash
 
+while getopts "hs:d:" arg; do
+	case $arg in
+		s) 
+		   sourceDirectory=$OPTARG
+		   ;;
+		
+		d) 
+		   destDirectory=$OPTARG
+		   ;;
+
+		h) 
+		   echo -e "This is the Honeypot Administration Tool (HAT)! This tool is intended to streamline some of the common dionaea honeypot administrator tasks.\n\nscript usage: $(basename $0) [-s] [-d] [-h]\n\t\t-s: The source directory for the captured dionaea binary files.\n\t\t-d: The destination directory for the binary samples from dionaea." >&2
+		   exit 0
+		   ;;
+
+		?)
+		   echo "script usage: $(basename $0) [-s] [-d] [-h]" >&2
+                   exit 1
+                   ;;
+
+	esac
+done
+
 #Determine if the current system can use the -n option to not print a newline
 if [ "'echo -n'" = "-n" ]
 then
@@ -106,14 +129,20 @@ read -r copyAnswer
 
 if [ "$copyAnswer" = "Y" ] || [ "$copyAnswer" = "y" ]
 then
-	#Ask the user for the source directory
-	echo $n "Please input the source directory for the binaries (include trailing /): $c"
-	read -r sourceDirectory
-	
-	#Ask the user for the destination directory
-	echo $n "Please input the destination directory for the binaries (include trailing /): $c"
-	read -r destDirectory
-	
+	#Ask the user for the source directory if it was not set by the option
+	if ! [ -d "$sourceDirectory" ]
+	then
+		echo $n "Please input the source directory for the binaries (include trailing /): $c"
+		read -r sourceDirectory
+	fi
+
+	#Ask the user for the destination directory if it was not set by the option
+	if ! [ -d "$destDirectory" ]
+	then
+		echo $n "Please input the destination directory for the binaries (include trailing /): $c"
+		read -r destDirectory
+	fi
+
 	if [ -d "$sourceDirectory" ] && [ -d "$destDirectory" ]
 	then
 
@@ -147,7 +176,20 @@ then
 	builtin type -P sampleScanner &> /dev/null && existCheck="1" || existCheck="0"
 	if [ $existCheck = "1" ]
 	then
-		sampleScanner
+		#Ask the User if they want to use the previously-used destination directory
+		if [ -d "$sourceDirectory" ]
+		then
+			echo $n "Scan all files in $sourceDirectory? [Y/N] (No will allow you to input another directory): $c"
+			read -r directoryAnswer
+			if [ "$scanAnswer" = "Y" ] || [ "$scanAnswer" = "y" ]
+			then
+				sampleScanner -s "$sourceDirectory"
+			else
+				sampleScanner
+			fi
+		else
+			sampleScanner
+		fi
 	else
 		echo "The sampleScanner tool is not detected. Make sure that sampleScanner is also in bin (either your ~/bin or /bin)."
 	fi

--- a/hat
+++ b/hat
@@ -11,12 +11,12 @@ while getopts "hs:d:" arg; do
 		   ;;
 
 		h) 
-		   echo -e "This is the Honeypot Administration Tool (HAT)! This tool is intended to streamline some of the common dionaea honeypot administrator tasks.\n\nscript usage: $(basename $0) [-s] [-d] [-h]\n\t\t-s: The source directory for the captured dionaea binary files.\n\t\t-d: The destination directory for the binary samples from dionaea." >&2
+		   echo -e "This is the Honeypot Administration Tool (HAT)! This tool is intended to streamline some of the common dionaea honeypot administrator tasks.\n\nscript usage: $(basename "$0") [-s] [-d] [-h]\n\t\t-s: The source directory for the captured dionaea binary files.\n\t\t-d: The destination directory for the binary samples from dionaea." >&2
 		   exit 0
 		   ;;
 
 		?)
-		   echo "script usage: $(basename $0) [-s] [-d] [-h]" >&2
+		   echo "script usage: $(basename "$0") [-s] [-d] [-h]" >&2
                    exit 1
                    ;;
 
@@ -181,7 +181,7 @@ then
 		then
 			echo $n "Scan all files in $sourceDirectory? [Y/N] (No will allow you to input another directory): $c"
 			read -r directoryAnswer
-			if [ "$scanAnswer" = "Y" ] || [ "$scanAnswer" = "y" ]
+			if [ "$directoryAnswer" = "Y" ] || [ "$directoryAnswer" = "y" ]
 			then
 				sampleScanner -s "$sourceDirectory"
 			else

--- a/hat
+++ b/hat
@@ -21,10 +21,10 @@ echo
 echo $n The current size of the dionaea log file is: "$c"
 find /opt/dionaea/var/log/dionaea/dionaea.log -printf "%6k KiB\n"
 echo $n dionaea tends to stop collecting samples once the log file reaches 2.0 GBs. Would you like to empty the dionaea log file? "[Y/N]:" "$c"
-read answer
+read -r answer
 
 #Now, compare the user's answer to determine the desired flow of execution
-if [ $answer = "Y" ] || [ $answer = "y" ]
+if [ "$answer" = "Y" ] || [ "$answer" = "y" ]
 then
 
 	if [ "$EUID" -ne 0 ]
@@ -49,7 +49,7 @@ then
 		#Now, let the user know that it is all done
 		echo "This portion of the script is finished! Remember to check back in to see what samples you caught!"
 	fi
-elif [ $answer = "N" ] || [ $answer = "n" ]
+elif [ "$answer" = "N" ] || [ "$answer" = "n" ]
 then
 	echo "The log has been left as-is"
 else
@@ -64,16 +64,14 @@ Options:
 	[U]nfiltered list
 	[F]iltered list
 	[N]o list
-
-Which list would you like to see? Enter your choice: ""$c"
-read listAnswer
+Which list would you like to see? Enter your choice: $c"
+read -r listAnswer
 
 #Now, compare the user's answer to determine the desired flow of execution
-if [ $listAnswer = "U" ] || [ $listAnswer = "u" ]
+if [ "$listAnswer" = "U" ] || [ "$listAnswer" = "u" ]
 then
 	#User wants an Unfiltered list
 	echo "Chosen list: [U]nfiltered
-
 The following is your unfiltered list of binaries:"
 	ls -lh1rt /opt/dionaea/var/lib/dionaea/binaries/
 
@@ -81,11 +79,10 @@ The following is your unfiltered list of binaries:"
 	echo $n "The length of the unfiltered list is: ""$c"
 	ls -lh1rt /opt/dionaea/var/lib/dionaea/binaries/ | wc -l
 
-elif [ $listAnswer = "F" ] || [ $listAnswer = "f" ]
+elif [ "$listAnswer" = "F" ] || [ "$listAnswer" = "f" ]
 then
 	#User wants a filtered list, so let's print the list, but without the 0-sized http* files
 	echo "Chosen list: [F]iltered
-
 The following is your filtered list of binaries:"
 	find /opt/dionaea/var/lib/dionaea/binaries/ -type f -size +0
 
@@ -93,11 +90,10 @@ The following is your filtered list of binaries:"
 	echo $n "The length of the filtered list is: ""$c"
 	find /opt/dionaea/var/lib/dionaea/binaries/ -type f -size +0 | wc -l
 
-elif [ $listAnswer = "N" ] || [ $listAnswer = "n" ]
+elif [ "$listAnswer" = "N" ] || [ "$listAnswer" = "n" ]
 then
 	#User does not want a list, so simply print an exit message, then exit
 	echo "Chosen list: [N]o list
-
 " 
 else
 	#The input was invalid
@@ -106,19 +102,19 @@ fi
 
 #Ask the user if they want to copy the binary list into a new directory
 echo $n "Would you like to copy the binaries into a new directory? Enter [Y/y]es or [N/n]o: ""$c"
-read copyAnswer
+read -r copyAnswer
 
-if [ $copyAnswer = "Y" ] || [ $copyAnswer = "y" ]
+if [ "$copyAnswer" = "Y" ] || [ "$copyAnswer" = "y" ]
 then
 	#Ask the user for the source directory
 	echo $n "Please input the source directory for the binaries (include trailing /): $c"
-	read sourceDirectory
+	read -r sourceDirectory
 	
 	#Ask the user for the destination directory
 	echo $n "Please input the destination directory for the binaries (include trailing /): $c"
-	read destDirectory
+	read -r destDirectory
 	
-	if [ -d $sourceDirectory ] && [ -d $destDirectory ]
+	if [ -d "$sourceDirectory" ] && [ -d "$destDirectory" ]
 	then
 
 		#Use find to select the binary files that are not empty
@@ -134,7 +130,7 @@ then
 	else
 		echo "One of the directories was invalid! Skipping..."
 	fi
-elif [ $copyAnswer = "N" ] || [ $copyAnswer = "n" ]
+elif [ "$copyAnswer" = "N" ] || [ "$copyAnswer" = "n" ]
 then
 	echo "Chose to not copy binaries. Skipping..."
 else
@@ -143,19 +139,19 @@ fi
 
 #Begin the VirusTotal scan of the binaries
 echo $n "Would you like to run VirusTotal scans on some samples binaries? Enter [Y/y]es or [N/n]o: ""$c"
-read scanAnswer
+read -r scanAnswer
 
-if [ $scanAnswer = "Y" ] || [ $scanAnswer = "y" ]
+if [ "$scanAnswer" = "Y" ] || [ "$scanAnswer" = "y" ]
 then
 	#Check to see if sampleScanner is a command that can be run (it must be located in bin)
 	builtin type -P sampleScanner &> /dev/null && existCheck="1" || existCheck="0"
-	if [ existCheck="1" ]
+	if [ $existCheck = "1" ]
 	then
 		sampleScanner
 	else
 		echo "The sampleScanner tool is not detected. Make sure that sampleScanner is also in bin (either your ~/bin or /bin)."
 	fi
-elif [ $scanAnswer = "N" ] || [ $scanAnswer = "n" ]
+elif [ "$scanAnswer" = "N" ] || [ "$scanAnswer" = "n" ]
 then
 	echo "You have chosen to perform no VirusTotal scan. Skipping ahead...
 "

--- a/installer.sh
+++ b/installer.sh
@@ -5,18 +5,18 @@
 echo "Welcome to the Honeypot Administration Tool (HAT) installer!"
 
 #Make sure that the user has their own bin directory
-if ! [ -d "~/bin/" ]
+if ! [ -d "$HOME/bin/" ]
 then
 	mkdir ~/bin/
 fi
 
 #Move the script files into the user's bin directory
-find . -type f -not -name "installer.sh" -exec cp {} ~/bin/
+find . -type f -not -name "installer.sh" -exec cp {} ~/bin/ +
 
 #Begin by cloning the GitHub page for the VirusTotal API that will be used
 git clone http://github.com/doomedraven/VirusTotalApi
 
-cd VirusTotalApi/
+cd VirusTotalApi/ || exit
 ./setup.py
 pip3 install -r requirements.txt
 

--- a/sampleScanner
+++ b/sampleScanner
@@ -8,6 +8,12 @@ while getopts 's:' OPTION; do
 	    sourceDirectory="$OPTARG"
 	    echo "Using the provided source directory: $sourceDirectory"
 	    ;;
+	  
+	  ?)
+	    echo "script usage: $(basename "$0") [-s]" >&2
+	    exit 1
+	    ;;
+	    
 	esac
 done
 
@@ -23,7 +29,6 @@ fi
 
 #Ask the user for the path to their vt.py file to use for scanning
 echo "This is the Sample Scanner! I will scan your binaries using VirusTotal!
-
 "
 
 

--- a/sampleScanner
+++ b/sampleScanner
@@ -2,6 +2,14 @@
 
 #This tool is intended to submit the malware samples collected by the honeypot to VirusTotal to decide if they are suitable
 
+while getopts 's:' OPTION; do
+	case "$OPTION" in
+	  s)
+	    sourceDirectory="$OPTARG"
+	    echo "Using the provided source directory: $sourceDirectory"
+	    ;;
+	esac
+done
 
 #Determine if the current system can use the -n option to not print a newline
 if [ "'echo -n'" = "-n" ]
@@ -15,27 +23,51 @@ fi
 
 #Ask the user for the path to their vt.py file to use for scanning
 echo "This is the Sample Scanner! I will scan your binaries using VirusTotal!
-"
-#Now, ask the user for the path to the directory with the binaries to scan
-echo $n "Please input the full path to the directory that contains the samples that you would like to scan:" "$c"
-read -r binaryPath
-#Show the user what they input, for clarity
-echo "You entered: ""$binaryPath" "
+
 "
 
-#Now, let's actually scan those samples in the provided directory
-path="$binaryPath"/*
-echo "Attempting to scan all files in ""$binaryPath"", as represented by the expression: ""$path"
 
-builtin type -P vt.py &> /dev/null && exister="1" || exister="0"
-if [ $exister = "1" ]
+#Check if the source directory (the directory that has the samples to scan) exists
+#If the variable contains a real directory, it must have been passed in as an option, so use it as the target for the scan
+if [ -d "$sourceDirectory" ]
 then
-	if [ -d "$binaryPath" ]
-	then
-		vt.py -s "$path" | tee virusTotalReport
-	else
-		echo "The path that you input does not exist. Exiting..."
-	fi
+	echo "Using the following source directory to get binaries to scan: $sourceDirectory"
+	
+	#Add the "*" wildcard to the end of the provided directory. This will let us target all of the files in the provided directory
+	path="$sourceDirectory"*
+        echo "Attempting to scan all files in ""$sourceDirectory"", as represented by the expression: ""$path"
+
+	#Make sure that vt.py is usable! exister=1 => vt.py can be used; exister=0 => vt.py cannot be used
+        builtin type -P vt.py &> /dev/null && exister="1" || exister="0"
+        if [ $exister = "1" ]
+        then
+		#vt.py exists, so use it and send the result to the standard output and to a file in the current directory
+                vt.py -s "$path" | tee virusTotalReport
+        else
+                echo "The file vt.py does not exist. Exiting..."
+        fi
 else
-	echo "The file vt.py does not exist. Exiting..."
+	#Now, ask the user for the path to the directory with the binaries to scan
+	echo $n "Please input the full path to the directory that contains the samples that you would like to scan:" "$c"
+	read -r binaryPath
+	#Show the user what they input, for clarity
+	echo "You entered: ""$binaryPath" "
+	"
+
+	#Now, let's actually scan those samples in the provided directory
+	path="$binaryPath"/*
+	echo "Attempting to scan all files in ""$binaryPath"", as represented by the expression: ""$path"
+
+	builtin type -P vt.py &> /dev/null && exister="1" || exister="0"
+	if [ $exister = "1" ]
+	then
+		if [ -d "$binaryPath" ]
+		then
+			vt.py -s "$path" | tee virusTotalReport
+		else
+			echo "The path that you input does not exist. Exiting..."
+		fi
+	else
+		echo "The file vt.py does not exist. Exiting..."
+	fi
 fi

--- a/sampleScanner
+++ b/sampleScanner
@@ -18,10 +18,9 @@ echo "This is the Sample Scanner! I will scan your binaries using VirusTotal!
 "
 #Now, ask the user for the path to the directory with the binaries to scan
 echo $n "Please input the full path to the directory that contains the samples that you would like to scan:" "$c"
-read binaryPath
+read -r binaryPath
 #Show the user what they input, for clarity
 echo "You entered: ""$binaryPath" "
-
 "
 
 #Now, let's actually scan those samples in the provided directory
@@ -29,11 +28,11 @@ path="$binaryPath"/*
 echo "Attempting to scan all files in ""$binaryPath"", as represented by the expression: ""$path"
 
 builtin type -P vt.py &> /dev/null && exister="1" || exister="0"
-if [ exister="1" ]
+if [ $exister = "1" ]
 then
 	if [ -d "$binaryPath" ]
 	then
-		vt.py -s $path | tee virusTotalReport
+		vt.py -s "$path" | tee virusTotalReport
 	else
 		echo "The path that you input does not exist. Exiting..."
 	fi


### PR DESCRIPTION
This will add the capability to use options when using the HAT, as well as several security fixes (more consistent quoting of variable usage, safer options used for the intake of user input, etc.).

The current list of available options is:
* \-s = source directory (where the binaries to be considered are stored)
* \-d = destination directory (mostly used for the copy capability)
* \-h = provides a short help statement with the available options and script usage format.